### PR TITLE
added single-node Elasticsearch for unit testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,23 @@ services:
       - db_xis
     networks:
       - openlxp
-
+  es01:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
+    container_name: es01
+    environment:
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+      - 9300:9300
+volumes:
+  data01:
+    driver: local
 networks:
   openlxp:
     external: true


### PR DESCRIPTION
added one-node Elasticsearch into 'docker-compose.yml' for unit testing purposes