### PR TITLE
Upgraded Django

### DIFF
--- a/app/openlxp_xis_project/urls.py
+++ b/app/openlxp_xis_project/urls.py
@@ -14,14 +14,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import url
+# from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, re_path
 
 urlpatterns = [
-    url('', include('openlxp_authentication.urls')),
-    path('admin/', admin.site.urls),
-    path('api/', include('api.urls')),
-    path('auth/', include('key_auth.urls'))
+    # url('', include('openlxp_authentication.urls')),
+    re_path('admin/', admin.site.urls),
+    re_path('api/', include('api.urls')),
+    re_path('auth/', include('key_auth.urls'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bleach~=6.0.0
 
-celery>=5.2.0, <5.2.3
+# celery>=5.2.0, <5.2.3
+celery >=5.2.3, <6.0
 
 coverage>=5.5,<6.0
 
@@ -8,9 +9,11 @@ confusable_homoglyphs==3.2.0
 
 ddt~=1.4.2 , <1.5.0
 
-Django>=3.2.3,<4.0.0
+# Django>=3.2.3,<4.0.0
+Django>=4.2,<5.0
 
-django-celery-beat >=2.2.1, <2.3.0
+# django-celery-beat >=2.2.1, <2.3.0
+django-celery-beat >=2.5.0, <2.6.0
 
 django-celery-results >=2.2.0, <2.3.0
 
@@ -24,7 +27,8 @@ django-rest-knox>=4.2.0,<4.3.0
 
 django-ses>=2.2.0 , <2.3.1
 
-djangorestframework>=3.13.0,<3.13.1
+# djangorestframework>=3.13.0,<3.13.1
+djangorestframework>=3.15.2,<3.16.0
 
 elasticsearch==7.11.0
 


### PR DESCRIPTION
Django upgraded to 4.2 because djangorestframework needed to be upgraded to 3.15.2. djangorestframework 3.15.2 required Django 4.0>. Celery also upgraded due Django 4.0 requiring 5.2.3>=